### PR TITLE
Remove raf polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6022,11 +6022,6 @@
         }
       }
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -8587,14 +8582,6 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
-    },
-    "raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "requires": {
-        "performance-now": "^2.1.0"
-      }
     },
     "read-pkg": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
   },
   "author": "dalphyx <wjcbmk@gmail.com>",
   "license": "MIT",
-  "dependencies": {
-    "raf": "^3.4.1"
-  },
+  "dependencies": {},
   "bugs": {
     "url": "https://github.com/dalphyx/vue-headroom/issues"
   },

--- a/src/headroom.vue
+++ b/src/headroom.vue
@@ -7,7 +7,6 @@
 </template>
 
 <script>
-import raf from 'raf'
 import checkActions from './checkActions'
 import support3d from './support3d'
 
@@ -240,7 +239,7 @@ export default {
     },
 
     _handleScroll () {
-      raf(this.update)
+      window.requestAnimationFrame(this.update)
     },
 
     _setHeightOffset () {
@@ -354,7 +353,7 @@ export default {
       this.translate = this.footroom ? '100%' : '-100%'
       this.$nextTick(() => {
         this.state = 'unpinned'
-      }) 
+      })
     },
 
     unfix () {


### PR DESCRIPTION
[RequestAnimationFrame has already widespread support](https://caniuse.com/mdn-api_window_requestanimationframe).

It negatively affects the performance for  most browsers so probably it would be better if only people targeting legacy browsers provided a polyfill.